### PR TITLE
LPS-117873 Provides a function called `updateEditingLanguageId` for updating `editingLanguageId` on FormProvider and clears some smells

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/dataEngineLayoutRendererLanguageProxy.es.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/dataEngineLayoutRendererLanguageProxy.es.js
@@ -15,7 +15,15 @@
 function onLocaleChange(layoutRendererInstance, event) {
 	const selectedLanguageId = event.item.getAttribute('data-value');
 
-	layoutRendererInstance.setState({editingLanguageId: selectedLanguageId});
+	const {
+		reactComponentRef: {current},
+	} = layoutRendererInstance;
+
+	if (current) {
+		current.updateEditingLanguageId({
+			editingLanguageId: selectedLanguageId,
+		});
+	}
 }
 
 export default function dataEngineLayoutRendererLanguageProxy(props) {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
@@ -58,7 +58,7 @@ function FieldBase({
 	valid,
 	visible,
 }) {
-	const {editingLanguageId = {}} = usePage();
+	const {editingLanguageId = themeDisplay.getLanguageId()} = usePage();
 	const dispatch = useForm();
 
 	const localizedValueArray = useMemo(() => {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/containers/Form.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/containers/Form.es.js
@@ -23,6 +23,7 @@ import React, {
 	useRef,
 } from 'react';
 
+import {EVENT_TYPES} from '../actions/eventTypes.es';
 import Pages from '../components/Pages.es';
 import {FormProvider, useForm} from '../hooks/useForm.es';
 import formValidate from '../thunks/formValidate.es';
@@ -136,6 +137,11 @@ const Form = React.forwardRef(
 				rules,
 				successPageSettings,
 			}),
+			updateEditingLanguageId: ({editingLanguageId}) =>
+				dispatch({
+					payload: {editingLanguageId},
+					type: EVENT_TYPES.ALL,
+				}),
 			validate,
 		}));
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/reducers/defaultReducer.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/reducers/defaultReducer.es.js
@@ -34,11 +34,8 @@ export default (state, action) => {
 							let value;
 
 							if (localizedValue) {
-								if (localizedValue[editingLanguageId.newVal]) {
-									value =
-										localizedValue[
-											editingLanguageId.newVal
-										];
+								if (localizedValue[editingLanguageId]) {
+									value = localizedValue[editingLanguageId];
 								}
 								else if (localizedValue[defaultLanguageId]) {
 									value = localizedValue[defaultLanguageId];

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/reducers/defaultReducer.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/reducers/defaultReducer.es.js
@@ -25,7 +25,7 @@ export default (state, action) => {
 				editingLanguageId &&
 				state.editingLanguageId !== editingLanguageId
 			) {
-				const visitor = new PagesVisitor(pages ?? action.pages);
+				const visitor = new PagesVisitor(pages ?? state.pages);
 
 				return {
 					...action.payload,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_8_0/UpgradeDDMStructure.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_8_0/UpgradeDDMStructure.java
@@ -531,7 +531,7 @@ public class UpgradeDDMStructure extends UpgradeProcess {
 	private void _upgradeStructureDefinition() throws Exception {
 		try (PreparedStatement ps1 = connection.prepareStatement(
 				"select * from DDMStructure where classNameId = ? or " +
-					"classNameId = ? ");
+					"classNameId = ? order by createDate");
 			PreparedStatement ps2 =
 				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
 					connection,

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/dataEngineLayoutRendererLanguageProxy.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/dataEngineLayoutRendererLanguageProxy.es.js
@@ -15,7 +15,15 @@
 function onLocaleChange(layoutRendererInstance, event) {
 	const selectedLanguageId = event.item.getAttribute('data-value');
 
-	layoutRendererInstance.setState({editingLanguageId: selectedLanguageId});
+	const {
+		reactComponentRef: {current},
+	} = layoutRendererInstance;
+
+	if (current) {
+		current.updateEditingLanguageId({
+			editingLanguageId: selectedLanguageId,
+		});
+	}
 }
 
 export default function dataEngineLayoutRendererLanguageProxy(props) {


### PR DESCRIPTION
From: https://github.com/marcelabc/liferay-portal/pull/261

### What I did:

We couldn't set state directly from the layoutRendererInstance, for solving it, a function called `updateEditingLanguageId` was provided from `reactComponentRef`'s imperativeHandler and was used for causing an update on FormProvider.

Also, some weird typos/smells was fixed on the code.

### How to test my changes(Test Case):
0. Go to osgi/configs folder and create a file called `com.liferay.journal.web.internal.configuration.JournalDDMEditorConfiguration.config` and paste `useDataEngineEditor=B"true"` within.

1. Go to Content and Data -> Web Content -> Create a new Structure
2. Place a Rich Text field there
3. Name and Save the structure 
4. Go back to the Web Content Menu, create a web content with the recently created structure
5. Fill some values on the default language(probably will be 'en-us'), then, change to 'pt-br' and fill with translated data.
6. Switch between languages

#### What was happening:

The user wasn't able to see the filled translated values on the title and within the content when switching languages.

#### Now(with the fix):

The user is able to switch and see translated content with the selected language.

/cc @matuzalemsteles @leoadb @marcelabc @jeyvison

Do I need to left a warning on #z-engineering-latam-common-issues for people that probably are working on a similar issue?